### PR TITLE
added third audio codec to output section

### DIFF
--- a/source/custom-resource-py/encoding-profiles/medialive-540p.json
+++ b/source/custom-resource-py/encoding-profiles/medialive-540p.json
@@ -130,6 +130,36 @@
 			}
 		},
 		"Outputs": [{
+			"AudioDescriptionNames": [
+				"audio_3_aac96"
+			],
+			"CaptionDescriptionNames": [],
+			"OutputSettings": {
+				"HlsOutputSettings": {
+					"HlsSettings": {
+						"StandardHlsSettings": {
+							"AudioRenditionSets": "PROGRAM_AUDIO",
+							"M3u8Settings": {
+								"AudioFramesPerPes": 4,
+								"AudioPids": "492-498",
+								"EcmPid": "8182",
+								"PcrControl": "PCR_EVERY_PES_PACKET",
+								"PmtPid": "480",
+								"ProgramNum": 1,
+								"Scte35Behavior": "PASSTHROUGH",
+								"Scte35Pid": "500",
+								"TimedMetadataPid": "502",
+								"TimedMetadataBehavior": "NO_PASSTHROUGH",
+								"VideoPid": "481"
+							}
+						}
+					},
+					"NameModifier": "_1280x540_2000k"
+				}
+			},
+			"VideoDescriptionName": "video_1280_540"
+		},
+		{
 				"AudioDescriptionNames": [
 					"audio_2_aac96"
 				],


### PR DESCRIPTION
**The creation of audio codec using 480p resolution fails with the error**

This is from CloudWatchLogs
```
REQUEST::Create::MediaLiveChannel
CONFIG::{'ServiceToken': 'arn:aws:lambda:us-east-1:<removed-account-number>:function:LiveStreaming-livestream-custom-resources', 'Role': 'arn:aws:iam::<removed-account-number>:role/LiveStreaming-MediaLiveRole-1EFC4ANRNVXU', 'MediaPackageSecUser': '85c8de68df70491095fafe23dd85fc40', 'Codec': 'AVC', 'Type': 'URL_PULL', 'Resource': 'MediaLiveChannel', 'InputId': '6389951', 'MediaPackageSecUrl': 'https://259f677efd9ce80a.mediapackage.us-east-1.amazonaws.com/in/v2/22352cd667db4fa897ad12924a89c27f/5d91054b02ac4e09bc8e5385727303a8/channel', 'MediaPackagePriUser': '0d51c61cc64e411089d79d37fd90eeb1', 'Name': 'LiveStreaming-livestream', 'MediaPackagePriUrl': 'https://a12d12520616dd39.mediapackage.us-east-1.amazonaws.com/in/v2/22352cd667db4fa897ad12924a89c27f/22352cd667db4fa897ad12924a89c27f/channel', 'Resolution': '480'}
Exception: An error occurred (UnprocessableEntityException) when calling the CreateChannel operation: audioDescriptions[5] Audio description "audio_3Aac96" is not referenced by any output; audioDescriptions[5] Audio description "audio_3Aac96" is not referenced by any output
```


Checking the encoding file I see that the 540p file is not referencing the audio "audio_3_aac96" in the output section.
```
wget https://raw.githubusercontent.com/awslabs/live-stream-on-aws/master/source/custom-resource-py/encoding-profiles/medialive-540p.json

grep -n audio_ *540p.json
21:			"Name": "audio_1_aac64"
34:			"Name": "audio_2_aac64"
47:			"Name": "audio_3_aac64"
60:			"Name": "audio_1_aac96"
73:			"Name": "audio_2_aac96"
86:			"Name": "audio_3_aac96"
134:					"audio_2_aac96"
164:					"audio_1_aac64"
194:					"audio_2_aac64"
224:					"audio_3_aac64"
254:					"audio_1_aac96"
```

I have added another section as a clone of audio_2_aac96 with different Name and NameModifier.
