### PR TITLE
Fix incorrect case in policy of CustomResourceRole

### DIFF
--- a/deployment/live-streaming-on-aws.yaml
+++ b/deployment/live-streaming-on-aws.yaml
@@ -196,28 +196,28 @@ Resources:
               -
                 Effect: Allow
                 Action:
-                  - medialive:createInputSecurityGroup
-                  - medialive:describeInput
-                  - medialive:createInput
-                  - medialive:deleteInput
-                  - medialive:stopChannel
-                  - medialive:createChannel
-                  - medialive:deleteChannel
-                  - medialive:describeInputSecurityGroup
-                  - medialive:deleteInputSecurityGroup
-                  - medialive:describeChannel
-                  - medialive:startChannel
-                  - medialive:tagResource
+                  - medialive:CreateInputSecurityGroup
+                  - medialive:DescribeInput
+                  - medialive:CreateInput
+                  - medialive:DeleteInput
+                  - medialive:StopChannel
+                  - medialive:CreateChannel
+                  - medialive:DeleteChannel
+                  - medialive:DescribeInputSecurityGroup
+                  - medialive:DeleteInputSecurityGroup
+                  - medialive:DescribeChannel
+                  - medialive:StartChannel
+                  - medialive:TagResource
                 Resource:
                     - !Join ["", ["arn:aws:medialive:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":*"]]
               -
                 Effect: Allow
                 Action:
-                  - mediapackage:createChannel
-                  - mediapackage:deleteChannel
-                  - mediapackage:listOriginEndpoints
-                  - mediapackage:deleteOriginEndpoint
-                  - mediapackage:createOriginEndpoint
+                  - mediapackage:CreateChannel
+                  - mediapackage:DeleteChannel
+                  - mediapackage:ListOriginEndpoints
+                  - mediapackage:DeleteOriginEndpoint
+                  - mediapackage:CreateOriginEndpoint
 
                 Resource:
                     - !Join ["", ["arn:aws:mediapackage:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":*"]]


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

The correct permission in IAM policy should start with capitalized letter after colon. Some policies for CustomResourceRole in this template use lower case letter instead. In my test the corresponding action will be denied.

This PR fixes the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
